### PR TITLE
Add a way to specify alternate base URLs for use in testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+
+## Influential Envorment Variables
+- `_WEBEDIT_ALTERNATE_BASE` - If this is defined, webedit will use it as the base for API calls, instead of the default.

--- a/public/we.lua
+++ b/public/we.lua
@@ -1,4 +1,10 @@
-local baseUrl = "http://we.haun.guru";
+local baseUrl;
+
+if _WEBEDIT_ALTERNATE_BASE then
+  baseURL = _WEBEDIT_ALTERNATE_BASE;
+else
+  baseUrl = "http://we.haun.guru";
+end
 
 local commandEndpoint = baseUrl .. "/getcmd";
 local responseEndpoint = baseUrl .."/response";


### PR DESCRIPTION
Webedit now will use a url specified in _WEBEDIT_ALTERNATE_BASE instead of the hardcoded default.
